### PR TITLE
Create cities model

### DIFF
--- a/app/controllers/cities_controller.rb
+++ b/app/controllers/cities_controller.rb
@@ -1,0 +1,10 @@
+class CitiesController < ApplicationController
+  def index
+    @cities = City.all
+  end
+
+  def show
+    @city = City.find(params[:id])
+  end
+  
+end

--- a/app/models/city.rb
+++ b/app/models/city.rb
@@ -1,0 +1,18 @@
+class City < ApplicationRecord
+  # has_many :activities
+
+  # belongs_to :city_journey
+
+  validates :latitude,
+            presence: true
+  validates :longitude,
+            presence: true
+  validates :name,
+            presence: true
+  validates :country,
+            presence: true
+  validates :continent,
+            presence: true
+  validates :region,
+            presence: true
+end

--- a/app/views/cities/index.html.erb
+++ b/app/views/cities/index.html.erb
@@ -1,0 +1,1 @@
+<h1> Here are all the cities </h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,5 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "articles#index"
+  resources :cities, only:[:index, :show]
 end

--- a/db/migrate/20221205135938_create_cities.rb
+++ b/db/migrate/20221205135938_create_cities.rb
@@ -1,0 +1,16 @@
+class CreateCities < ActiveRecord::Migration[7.0]
+  def change
+    create_table :cities do |t|
+      t.string :name
+      t.string :tags
+      t.text :description
+      t.float :latitude
+      t.float :longitude
+      t.string :region
+      t.string :country
+      t.string :continent
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_05_134358) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_05_135938) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "cities", force: :cascade do |t|
+    t.string "name"
+    t.string "tags"
+    t.text "description"
+    t.float "latitude"
+    t.float "longitude"
+    t.string "region"
+    t.string "country"
+    t.string "continent"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false

--- a/test/controllers/cities_controller_test.rb
+++ b/test/controllers/cities_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CitiesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/city_test.rb
+++ b/test/models/city_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CityTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Adds city model -

city has 

t.string "name"
    t.string "tags"
    t.text "description"
    t.float "latitude"
    t.float "longitude"
    t.string "region"
    t.string "country"
    t.string "continent"
    t.datetime "created_at", null: false
    t.datetime "updated_at", null: false

and all must be present APART from a tag, where a city may not have a specific tag.

creates a city controller --

should user want to access all cities, and find featured trips created by other users, a 'show'/'index' method will be required.