### PR TITLE
Adds custom map with simple theme, and simple popups

### DIFF
--- a/app/assets/images/map-pin.svg
+++ b/app/assets/images/map-pin.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" viewBox="0 0 24 24" fill="none" stroke="#a8cdca" stroke-width="1" stroke-linecap="round" stroke-linejoin="round" class="feather feather-map-pin"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"></path><circle cx="12" cy="10" r="3"></circle></svg>

--- a/app/assets/stylesheets/components/_address_autocomplete.scss
+++ b/app/assets/stylesheets/components/_address_autocomplete.scss
@@ -1,7 +1,7 @@
 .mapboxgl-ctrl-geocoder {
   max-width: none;
   width: 100%;
-  border: 1px solid lightgrey;
+  border: 1px solid transparent;
   box-shadow: none;
   background-color: transparent;
 }

--- a/app/assets/stylesheets/components/_map.scss
+++ b/app/assets/stylesheets/components/_map.scss
@@ -1,12 +1,37 @@
+.mapboxgl-popup {
+  text-align: center;
+  font-family: $body-font;
+  width: 15vw;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
 .mapboxgl-popup-content {
   text-align: center;
   font-family: $body-font;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  border-radius: $border-radius-sm !important;
+  background: $black !important;
+  color: $white;
+}
+.mapboxgl-popup-tip {
+  border-top-color: $black !important;
+  border-bottom-color: $black !important;
+  color: $white;
+}
+.mapboxgl-popup-close-button {
+  color: $white;
 }
 .marker {
-  background-image: url('droplet.svg');
+  background-image: url('map-pin.svg');
   background-size: cover;
-  width: 25px;
-  height: 25px;
+  width: 40px;
+  height: 40px;
   border-radius: 50%;
   cursor: pointer;
 }

--- a/app/assets/stylesheets/components/_show_banner.scss
+++ b/app/assets/stylesheets/components/_show_banner.scss
@@ -1,4 +1,10 @@
 .show-banner {
+  -webkit-touch-callout: none; /* iOS Safari */
+  -webkit-user-select: none; /* Safari */
+  -khtml-user-select: none; /* Konqueror HTML */
+  -moz-user-select: none; /* Old versions of Firefox */
+  -ms-user-select: none; /* Internet Explorer/Edge */
+  user-select: none;
   height:90vh;
   width: 100vw;
   display: flex;

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -9,7 +9,7 @@ export default class extends Controller {
   }
  #addMarkersToMap() {
     this.markersValue.forEach((marker) => {
-      const popup = new mapboxgl.Popup().setHTML(marker.info_window)
+      const popup = new mapboxgl.Popup({focusAfterOpen: false}).setHTML(marker.info_window)
       const el = document.createElement('div');
       el.className = 'marker';
 
@@ -29,7 +29,7 @@ export default class extends Controller {
 
     this.map = new mapboxgl.Map({
       container: this.element,
-      style: "mapbox://styles/mapbox/streets-v12"
+      style: "mapbox://styles/ajcj1/clcrsz49200f814ldl897pgo1"
     })
     this.#addMarkersToMap()
     this.#fitMapToMarkers()

--- a/app/views/journeys/_info_window.html.erb
+++ b/app/views/journeys/_info_window.html.erb
@@ -1,2 +1,2 @@
-<h2><%= city.name %></h2>
-<p><%= city.region %></p>
+<h2 class="text-center"><%= city.name %></h2>
+<p class="text-center"><%= city.region %></p>


### PR DESCRIPTION
This push adds a custom mapbox with a light theme and light green for water. it replaces the old SVG for markers, and styles the popups to be plain $black with white text, removing the 'focus' for the close button when initially clicked, and giving the popup some border radius.

Old:
![Screenshot 2023-01-11 at 16 16 13](https://user-images.githubusercontent.com/108676317/211858692-1069e5f9-0f37-4293-b80d-52b6c0980736.png)

New:
![Screenshot 2023-01-11 at 16 16 27](https://user-images.githubusercontent.com/108676317/211858705-8d0b1839-c86f-4f3a-b393-44c4e139d81f.png)
